### PR TITLE
Updated the instructions on how to use cookiecutter with pipx

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,16 +6,17 @@
 
 * Using [poetry](https://python-poetry.org/) to manage dependencies
 
-* Using [django-configurations](https://github.com/jazzband/django-configurations) to setup a class based, different environments in settings, most configurations defined with environment variables
+* Using [django-configurations](https://github.com/jazzband/django-configurations) to setup a class based, different
+  environments in settings, most configurations defined with environment variables
 
 * Postgresql as a default db
 
 * [Gunicorn](https://gunicorn.org/) for production serving
 
 * Django's goodies including:
-  * [django-storages](https://django-storages.readthedocs.io/en/latest/) for storage backends.
-  * [django-extensions](https://django-extensions.readthedocs.io/en/stable/).
-  * [django-import-export](https://django-import-export.readthedocs.io/en/stable/) plugin for the admin
+    * [django-storages](https://django-storages.readthedocs.io/en/latest/) for storage backends.
+    * [django-extensions](https://django-extensions.readthedocs.io/en/stable/).
+    * [django-import-export](https://django-import-export.readthedocs.io/en/stable/) plugin for the admin
 
 * Cors middleware and [querycount](https://github.com/bradmontgomery/django-querycount) middleware, timezone middleware
 
@@ -25,19 +26,37 @@
 
 * Deployable: Built in aws codebuild, Working dockerfile, nginx to serve static files, aws boto for s3 integration
 
-* health check endpoint 
+* health check endpoint
 * Ready with initial ci for github actions or codebuild aws ci
+
 ### Easy local development for frontend users
 
-Ability to run this whole project with 
+Ability to run this whole project with
+
 ```bash
 docker-compose up --build
 ```
+
 ## Expected configuration:
+
 - project_name in underscore format
 - git_repo link
 
+## Prerequisite
+
+1. Pipx - The recommended way to install and run
+   cookiecutter - [Install Pipx instructions](https://github.com/pypa/pipx?tab=readme-ov-file#install-pipx)
+
+2. Cookiecutter - Install cookiecutter with
+   pipx [Documentation](https://cookiecutter.readthedocs.io/en/stable/README.html#installation)
+    ```shell
+   pipx install cookiecutter
+    ```
+
 ## How to work with this
 
-1. ```pip install cookiecutter``` if not installed yet
-2. ```cookiecutter https://github.com/alonisser/django-poetry-opinionated-cookiecutter```
+1. Install the prerequisites
+2. Run cookiecutter with this template
+    ```shell
+    pipx run cookiecutter https://github.com/alonisser/django-poetry-opinionated-cookiecutte
+    ```


### PR DESCRIPTION
I'm running this on a new PC and I've noticed that Cookiecutter says Pipx is the recommended method,:

```
Install cookiecutter using pip package manager:

# pipx is strongly recommended.
pipx install cookiecutter

# If pipx is not an option,
# you can install cookiecutter in your Python user directory.
python -m pip install --user cookiecutter
```

So I've updated the docs a bit