### PR TITLE
Added DEFAULT_AUTO_FIELD from the django startproject template

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}/settings.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}/settings.py
@@ -172,6 +172,10 @@ class Base(Configuration):
     MEDIA_ROOT = values.Value(BASE_DIR / 'media')
     MEDIA_URL = '/media/'
 
+    # Default primary key field type
+    # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
+    DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'
+
 
 class Development(Base):
     CORS_ALLOW_ALL_ORIGINS = True
@@ -215,9 +219,9 @@ class Production(Base):
 
     MIDDLEWARE = [
         'django.middleware.security.SecurityMiddleware',
-        { % - if cookiecutter.heroku_app_name | length - %}
+        {%- if cookiecutter.heroku_app_name | length -%}
         'whitenoise.middleware.WhiteNoiseMiddleware',
-        { % - endif - %}
+        {%- endif -%}
         'django.contrib.sessions.middleware.SessionMiddleware',
         'corsheaders.middleware.CorsMiddleware',
         'django.middleware.common.CommonMiddleware',


### PR DESCRIPTION
הסתכלתי איך נראה הקובץ settings של פרוייקט חדש בדג'נגו 5, נראה שהוסיפו חלק שמגדיר את הסוג שדה הדיפולטיבי בשביל auto_field

```python
    # Default primary key field type
    # https://docs.djangoproject.com/en/5.0/ref/settings/#default-auto-field
    DEFAULT_AUTO_FIELD = 'django.db.models.BigAutoField'

```