### PR TITLE
Redirect from http to https at application level

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}/settings.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}/settings.py
@@ -218,6 +218,10 @@ class Production(Base):
     AWS_STORAGE_BUCKET_NAME = values.Value(environ_name="S3_STORAGE")
     # If heroku Add buckateer for s3 intergration
 
+    # Redirect from http to https at application level (needed for Heroku)
+    SECURE_PROXY_SSL_HEADER = ('HTTP_X_FORWARDED_PROTO', 'https')
+    SECURE_SSL_REDIRECT = True
+
     MIDDLEWARE = [
         'django.middleware.security.SecurityMiddleware',
         {%- if cookiecutter.heroku_app_name|length %}


### PR DESCRIPTION
Adds a redirect from http to https at application level

This is needed for Heroku, and not a bad thing to have on production environments
https://help.heroku.com/J2R1S4T8/can-heroku-force-an-application-to-use-ssl-tls