### PR TITLE
added a step to manually install heroku cli

### DIFF
--- a/{{cookiecutter.project_name}}/.github/workflows/ci.yml
+++ b/{{cookiecutter.project_name}}/.github/workflows/ci.yml
@@ -61,6 +61,8 @@ jobs:
     needs: [ test-job ]
     runs-on: ubuntu-22.04
     steps:
+      - name: Install Heroku CLI
+        run: curl https://cli-assets.heroku.com/install.sh | sh
       - name: Check out repository code
         uses: actions/checkout@v4
       - name: Deploying to heroku


### PR DESCRIPTION
The image `ubuntu-latest` that we use no longer supports `heroku-cli` by defualt.

see here: https://github.com/AkhileshNS/heroku-deploy?tab=readme-ov-file#important-note

Solution: manually install with the official Heroku CLI installer