### PR TITLE
updated the s3 backend import

### DIFF
--- a/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}/settings.py
+++ b/{{cookiecutter.project_name}}/{{cookiecutter.__project_slug}}/settings.py
@@ -165,7 +165,7 @@ class Base(Configuration):
 
     STORAGES = {
         "default":
-            {"BACKEND": 'storages.backends.s3boto3.S3Boto3Storage'},
+            {"BACKEND": 'storages.backends.s3.S3Storage'},
         "staticfiles":
             {"BACKEND": 'django.contrib.staticfiles.storage.StaticFilesStorage'}
 


### PR DESCRIPTION
It seems [django-storages](https://django-storages.readthedocs.io/en/latest/index.html) updated their import path for s3 boto.
I didn't find any release notes to check when was it changed.

I guess it happened in Sep 2023 - 
https://github.com/jschneier/django-storages/commit/e1c3b38cc2e6c5bc8330db046386a0541dd1d39e

----

The current import path is documented here:
https://django-storages.readthedocs.io/en/latest/backends/amazon-S3.html#configuration-settings
```python
STORAGES = {
    "default": {
        "BACKEND": "storages.backends.s3.S3Storage",
...
```


But the one used in this cookie-cutter repo will still work because they did keep it backward compatible as seen here:
https://github.com/jschneier/django-storages/blob/master/storages/backends/s3boto3.py